### PR TITLE
Improved statistics reporting

### DIFF
--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -40,10 +40,10 @@ mod problem_analysis;
 mod flatten_cnf;
 
 /// Contains stuff on reporting the result of a proof search.
-mod proof_result;
+pub mod proof_result;
 
 /// Contains stuff on statistics collected during a proof search.
-mod proof_statistics;
+pub mod proof_statistics;
 
 /// Contains stuff for keeping track of the current proof state during a proof search.
 mod proof_state;

--- a/src/prover/proof_result.rs
+++ b/src/prover/proof_result.rs
@@ -22,6 +22,7 @@ pub enum ProofResult {
     CounterSatisfiable,
     Unsatisfiable,
     Satisfiable,
+    GaveUp,
     Timeout,
     Error(String),
 }
@@ -42,6 +43,36 @@ impl ProofResult {
             ProofResult::CounterSatisfiable
         } else {
             ProofResult::Satisfiable
+        }
+    }
+    
+    /// Returns a String which describes the type of the ProofResult.
+    /// The reason for this is function is trouble with SZS format output.
+    pub fn display_type(&self) -> String {
+        match *self {
+            ProofResult::Theorem => "Theorem".to_owned(),
+            ProofResult::CounterSatisfiable => "CounterSatisfiable".to_owned(),
+            ProofResult::Unsatisfiable => "Unsatisfiable".to_owned(),
+            ProofResult::Satisfiable => "Satisfiable".to_owned(),
+            ProofResult::GaveUp => "GaveUp".to_owned(),
+            ProofResult::Timeout => "Timeout".to_owned(),
+            ProofResult::Error(_) => "Error".to_owned()
+        }
+    }
+    
+    /// Is the current result successful (in the sense that a proof of some kind was found)?
+    pub fn is_successful(&self) -> bool {
+        match *self {
+            ProofResult::Timeout | ProofResult::Error(_) => false,
+            _ => true
+        }
+    }
+    
+    /// Is the current result an error?
+    pub fn is_err(&self) -> bool {
+        match *self {
+            ProofResult::Error(_) => true,
+            _ => false,
         }
     }
 }

--- a/src/prover/proof_statistics.rs
+++ b/src/prover/proof_statistics.rs
@@ -16,30 +16,51 @@
 
 /// Contains statistics for the current proof search.
 #[derive(Eq, PartialEq, Clone, Debug, Copy)]
+#[allow(missing_docs)]
 pub struct ProofStatistics {
+    pub initial_clauses: usize,
     pub elapsed_ms: u64,
     pub iterations: u64,
+    pub trivial_count: u64,
     pub fs_count: u64,
     pub bs_count: u64,
     pub sp_count: u64,
     pub ef_count: u64,
     pub er_count: u64,
-    pub trivial_count: u64,
+    pub trivial_inference_count: u64,
 }
 
 impl ProofStatistics {
     /// Creates a new statistics container.
     pub fn new() -> ProofStatistics {
         ProofStatistics {
+            initial_clauses: 0,
             elapsed_ms: 0,
             iterations: 0,
+            trivial_count: 0,
             fs_count: 0,
             bs_count: 0,
             sp_count: 0,
             ef_count: 0,
             er_count: 0,
-            trivial_count: 0,
+            trivial_inference_count: 0,
         }
+    }
+    
+    /// Returns the amount of nonredundant processed clauses.
+    pub fn nonredudant_processed_count(&self) -> u64 {
+        self.iterations - self.trivial_count - self.fs_count
+    }
+    
+    /// Returns the amount of inferred clauses.
+    pub fn inferred_clauses_count(&self) -> u64 {
+        self.sp_count + self.ef_count + self.er_count
+    }
+    
+    /// Returns the amount of nontrivial inferred clauses.
+    /// That is, the amount of clauses not immediately discarded.
+    pub fn nontrivial_inferred_clauses_count(&self) -> u64 {
+        self.inferred_clauses_count() - self.trivial_inference_count
     }
 }
 

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -38,6 +38,14 @@ macro_rules! assert_neq {
     })
 }
 
+/// A println which appends "% " to the start of everything to print.
+/// Avoids lots of annoying work when printing stuff in the SZS format.
+#[macro_export]
+macro_rules! println_szs {
+    ($fmt:expr) => (print!(concat!("% ", concat!($fmt, "\n"))));
+    ($fmt:expr, $($arg:tt)*) => (print!(concat!("% ", concat!($fmt, "\n")), $($arg)*));
+}
+
 #[cfg(test)]
 mod test {
     #[test]


### PR DESCRIPTION
Improved the way statistics are reported. Previously we might have something like 

    Serkr 0.1.0, (C) 2015-2016 Mikko Aarnos
    Initial clauses: 28
    info time 1009 iterations 713 used 51 unused 1331 sp 2176 ef 0 er 0 trivial 160 fs 661 bs 0
    info time 2001 iterations 1105 used 56 unused 2624 sp 3889 ef 0 er 0 trivial 188 fs 1048 bs 0
    info time 3002 iterations 1391 used 58 unused 3246 sp 4813 ef 0 er 0 trivial 204 fs 1332 bs 0
    info time 4003 iterations 1612 used 58 unused 3025 sp 4813 ef 0 er 0 trivial 204 fs 1553 bs 0
    info time 5001 iterations 1833 used 58 unused 2804 sp 4813 ef 0 er 0 trivial 204 fs 1774 bs 0
    info time 6006 iterations 2045 used 58 unused 2592 sp 4813 ef 0 er 0 trivial 204 fs 1986 bs 0
    info time 7005 iterations 2271 used 58 unused 2366 sp 4813 ef 0 er 0 trivial 204 fs 2212 bs 0
    info time 8003 iterations 2526 used 58 unused 2111 sp 4813 ef 0 er 0 trivial 204 fs 2467 bs 0
    info time 9001 iterations 2875 used 74 unused 2889 sp 6080 ef 0 er 0 trivial 344 fs 2799 bs 1
    info time 10001 iterations 3289 used 90 unused 3872 sp 7622 ef 0 er 0 trivial 489 fs 3197 bs 1
    info time 11001 iterations 3793 used 128 unused 4934 sp 9216 ef 0 er 0 trivial 517 fs 3663 bs 1
    info time 12007 iterations 4231 used 152 unused 6671 sp 11391 ef 0 er 0 trivial 517 fs 4077 bs 1
    info time 13002 iterations 4577 used 164 unused 7535 sp 12601 ef 0 er 0 trivial 517 fs 4411 bs 1
    info time 14001 iterations 4855 used 164 unused 7257 sp 12601 ef 0 er 0 trivial 517 fs 4689 bs 1
    info time 15001 iterations 5199 used 164 unused 6913 sp 12601 ef 0 er 0 trivial 517 fs 5033 bs 1
    info time 16007 iterations 5550 used 185 unused 8207 sp 14246 ef 0 er 0 trivial 517 fs 5363 bs 1
    info time 17001 iterations 5869 used 193 unused 8581 sp 14939 ef 0 er 0 trivial 517 fs 5674 bs 1
    info time 18003 iterations 6167 used 193 unused 8283 sp 14939 ef 0 er 0 trivial 517 fs 5972 bs 1
    info time 19001 iterations 6520 used 197 unused 8225 sp 15234 ef 0 er 0 trivial 517 fs 6321 bs 1
    info time 20003 iterations 6808 used 200 unused 8152 sp 15449 ef 0 er 0 trivial 517 fs 6606 bs 1
    info time 21001 iterations 7129 used 226 unused 10247 sp 17912 ef 0 er 0 trivial 564 fs 6900 bs 2
    info time 22003 iterations 7483 used 244 unused 11624 sp 19706 ef 0 er 0 trivial 627 fs 7236 bs 2
    info time 23004 iterations 7807 used 268 unused 13504 sp 21910 ef 0 er 0 trivial 627 fs 7536 bs 2
    info time 24001 iterations 8103 used 287 unused 14737 sp 23453 ef 0 er 0 trivial 641 fs 7813 bs 2
    info time 25002 iterations 8280 used 289 unused 14764 sp 23657 ef 0 er 0 trivial 641 fs 7988 bs 2
    info time 26006 iterations 8449 used 290 unused 14629 sp 23691 ef 0 er 0 trivial 641 fs 8156 bs 2
    info time 27002 iterations 8680 used 296 unused 14846 sp 24139 ef 0 er 0 trivial 641 fs 8381 bs 2
    info time 28002 iterations 8870 used 300 unused 14940 sp 24478 ef 0 er 0 trivial 696 fs 8567 bs 2
    info time 29001 iterations 9118 used 307 unused 15096 sp 24907 ef 0 er 0 trivial 721 fs 8808 bs 2
    info time 30001 iterations 9339 used 307 unused 14875 sp 24907 ef 0 er 0 trivial 721 fs 9029 bs 2
    info time 31010 iterations 9542 used 308 unused 14690 sp 24957 ef 0 er 0 trivial 753 fs 9231 bs 2
    info time 32001 iterations 9773 used 325 unused 14946 sp 25768 ef 0 er 0 trivial 1077 fs 9444 bs 3
    Theorem
    Time elapsed (in ms): 32238

which isn't terribly informative. Now we have

    % SZS status Theorem for examples/SWV236+1.p
    % SZS output None for examples/SWV236+1.p : Proof output is not yet supported

    % Time elapsed (in ms): 22832
    % Initial clauses: 28
    % Analyzed clauses: 9756
    %   Trivial: 973
    %   Forward subsumed: 8447
    %   Nonredundant: 336
    % Backward subsumptions: 5
    % Inferred clauses: 26197
    %   Superposition: 26197
    %   Equality factoring: 0
    %   Equality resolution: 0
    % Nontrivial inferred clauses: 24894

which should be better. The current output style should also comform (mostly) to the SZS ontology. The only real missing part is the proof output which is going to need some work.