### PR TITLE
Clause selection improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,12 +2,12 @@
 name = "serkr"
 version = "0.1.0"
 dependencies = [
- "clap 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -53,14 +53,19 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clap"
-version = "2.2.5"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -87,7 +92,7 @@ name = "docopt"
 version = "0.6.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -126,8 +131,8 @@ dependencies = [
  "lalrpop-snap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -149,7 +154,7 @@ dependencies = [
  "lalrpop-intern 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -265,19 +270,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.66"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -305,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -328,11 +333,10 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -369,14 +373,6 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,11 +380,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vec_map"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "void"
-version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,11 @@ name = "serkr"
 version = "0.1.0"
 dependencies = [
  "clap 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -29,8 +29,8 @@ name = "atty"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -59,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "clippy"
-version = "0.0.62"
+version = "0.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quine-mc_cluskey 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,7 +87,7 @@ name = "docopt"
 version = "0.6.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -104,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,7 +126,7 @@ dependencies = [
  "lalrpop-snap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -149,7 +149,7 @@ dependencies = [
  "lalrpop-intern 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -160,7 +160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -168,13 +168,8 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "mempool"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
@@ -183,12 +178,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "num-complex"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "petgraph"
@@ -208,18 +260,18 @@ name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.63"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mempool 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -261,8 +313,26 @@ name = "term"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -270,8 +340,8 @@ name = "time"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -299,6 +369,14 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +384,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vec_map"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/src/prover/clause_selection/clause_weight.rs
+++ b/src/prover/clause_selection/clause_weight.rs
@@ -1,0 +1,87 @@
+// Serkr - An automated theorem prover. Copyright (C) 2015-2016 Mikko Aarnos.
+//
+// Serkr is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Serkr is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Serkr. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use std::cmp::Ordering;
+use prover::data_structures::clause::Clause;
+use prover::data_structures::literal::Literal;
+use prover::data_structures::term::Term;
+
+/// Different ways to give weights to clauses.
+/// Trying to order different variants in the enum results in a panic.
+#[derive(PartialEq, Eq)]
+pub enum ClauseWeight {
+    /// Based on the size of the clause.
+    /// Contains the ID and the symbol count of the clause.
+    Size(u64, u64),
+    /// Based on the age of the clause. Contains the ID of the clause.
+    Age(u64),
+}
+
+impl ClauseWeight {
+    /// Creates a new weight based on the symbol count of the clause.
+    /// The variable 'f_value' is the value to give to function symbols.
+    /// Then 'v_value' is just the value to give to variables.
+    pub fn new_size_weight(cl: &Clause, f_value: u64, v_value: u64) -> ClauseWeight {
+        ClauseWeight::Size(cl.get_id(), clause_symbol_count(cl, f_value, v_value))
+    }
+    
+    /// Creates a new weight based on the age of the clause.
+    pub fn new_age_weight(clause: &Clause) -> ClauseWeight {
+        ClauseWeight::Age(clause.get_id())
+    }
+    
+    /// Get the ID of the clause a particular clause weight is associated with.
+    pub fn get_id(&self) -> u64 {
+        match *self {
+            ClauseWeight::Size(id, _) |
+            ClauseWeight::Age(id) => id,
+        }
+    }
+}
+
+impl PartialOrd for ClauseWeight {
+    fn partial_cmp(&self, other: &ClauseWeight) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ClauseWeight {
+    fn cmp(&self, other: &ClauseWeight) -> Ordering {
+        // Since BinaryHeap is a max heap, the comparison is inverted.
+        match (self, other) {
+            (&ClauseWeight::Size(_, weight1), &ClauseWeight::Size(_, weight2)) => weight2.cmp(&weight1),
+            (&ClauseWeight::Age(id1), &ClauseWeight::Age(id2)) => id2.cmp(&id1),
+             _ => panic!("faulty comparision")
+        }
+    }
+}
+
+fn clause_symbol_count(cl: &Clause, f_value: u64, v_value: u64) -> u64 {
+    cl.iter().fold(0, |acc, l| acc + literal_symbol_count(l, f_value, v_value))
+}
+    
+fn literal_symbol_count(l: &Literal, f_value: u64, v_value: u64) -> u64 {
+    f_value + term_symbol_count(l.get_lhs(), f_value, v_value) 
+            + term_symbol_count(l.get_rhs(), f_value, v_value)
+}
+    
+fn term_symbol_count(t: &Term, f_value: u64, v_value: u64) -> u64 {
+    if t.is_variable() {
+        v_value
+    } else {
+        t.iter().fold(f_value, |acc, sub_t| acc + term_symbol_count(sub_t, f_value, v_value))
+    }
+}

--- a/src/prover/clause_selection/clause_weight.rs
+++ b/src/prover/clause_selection/clause_weight.rs
@@ -74,8 +74,8 @@ fn clause_symbol_count(cl: &Clause, f_value: u64, v_value: u64) -> u64 {
 }
     
 fn literal_symbol_count(l: &Literal, f_value: u64, v_value: u64) -> u64 {
-    f_value + term_symbol_count(l.get_lhs(), f_value, v_value) 
-            + term_symbol_count(l.get_rhs(), f_value, v_value)
+    term_symbol_count(l.get_lhs(), f_value, v_value) + 
+    term_symbol_count(l.get_rhs(), f_value, v_value)
 }
     
 fn term_symbol_count(t: &Term, f_value: u64, v_value: u64) -> u64 {

--- a/src/prover/clause_selection/heuristic.rs
+++ b/src/prover/clause_selection/heuristic.rs
@@ -1,0 +1,40 @@
+// Serkr - An automated theorem prover. Copyright (C) 2015-2016 Mikko Aarnos.
+//
+// Serkr is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Serkr is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Serkr. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use prover::data_structures::clause::Clause;
+use prover::clause_selection::clause_weight::ClauseWeight;
+
+/// Different heuristics for ordering clauses.
+#[allow(dead_code)]
+#[derive(PartialEq, Eq)]
+pub enum Heuristic {
+    /// Heuristic based on the symbol count of the clause.
+    /// First number is the value to give to functions.
+    /// The other number is the value to give to variables.
+    Size(u64, u64),
+    /// Heuristic based on clause age.
+    Age,
+}
+
+impl Heuristic {
+    /// Creates a new ClauseWeight corresponding to the heuristic for a given clause.
+    pub fn new_clauseweight(&self, cl: &Clause) -> ClauseWeight {
+        match *self {
+            Heuristic::Size(f_val, v_val) => ClauseWeight::new_size_weight(cl, f_val, v_val),
+            Heuristic::Age => ClauseWeight::new_age_weight(cl)
+        }
+    }
+}

--- a/src/prover/clause_selection/mod.rs
+++ b/src/prover/clause_selection/mod.rs
@@ -1,0 +1,26 @@
+// Serkr - An automated theorem prover. Copyright (C) 2015-2016 Mikko Aarnos.
+//
+// Serkr is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Serkr is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Serkr. If not, see <http://www.gnu.org/licenses/>.
+//
+
+/// Contains different ways to give clauses a weight.
+pub mod clause_weight;
+
+/// Contains different heuristics to give clauses a weight.
+/// This and clause_weight are tightly connected.
+/// Is there some nice way to combine them both?
+pub mod heuristic;
+
+/// Contains functions for picking the next heuristic and clause.
+pub mod pick_best;

--- a/src/prover/clause_selection/pick_best.rs
+++ b/src/prover/clause_selection/pick_best.rs
@@ -1,0 +1,52 @@
+// Serkr - An automated theorem prover. Copyright (C) 2015-2016 Mikko Aarnos.
+//
+// Serkr is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Serkr is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Serkr. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use std::collections::{HashMap, BinaryHeap};
+use prover::data_structures::clause::Clause;
+use prover::clause_selection::clause_weight::ClauseWeight;
+
+/// Chooses the best clause according to the ordering given, if possible.
+pub fn pick_best_clause(clauses: &mut HashMap<u64, Clause>, clause_order: &mut BinaryHeap<ClauseWeight>) -> Option<Clause> {
+    assert!(clauses.len() <= clause_order.len());
+    
+    // Other heuristics might have already picked the best one, so we need to loop.
+    while let Some(clause_weight) = clause_order.pop() {
+        if let Some(clause) = clauses.remove(&clause_weight.get_id()) {
+            assert_eq!(clause.get_id(), clause_weight.get_id());
+            return Some(clause);
+        }
+    }
+    
+    None
+}
+
+/// Picks the next heuristic to use. Also updates 'current_heuristic_count'.
+pub fn choose_heuristic(heuristic_use_count: &[usize], current_heuristic_count: &mut usize) -> usize {
+    let mut running_total = 0;
+    
+    for (i, x) in heuristic_use_count.iter().enumerate() {
+        running_total += *x;
+        if *current_heuristic_count < running_total {
+            *current_heuristic_count += 1;
+            return i;
+        }
+    }
+    
+    // If we didn't find anything we need to reset the counter.
+    assert_eq!(*current_heuristic_count, heuristic_use_count.iter().fold(0, |acc, x| acc + x));
+    *current_heuristic_count = 0;
+    0
+}

--- a/src/prover/data_structures/clause.rs
+++ b/src/prover/data_structures/clause.rs
@@ -16,13 +16,12 @@
 
 use std::ops::Index;
 use std::slice::{Iter, IterMut};
-use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter, Error};
 use prover::data_structures::literal::Literal;
 use prover::unification::substitution::Substitution;
 
 /// A multiset containing literals.
-// TODO: Eq and PartialEq are nonsensical at the moment but proper solutions would be expensive.
+/// Here also Eq and PartialEq and intensional instead of extensional.
 #[derive(Eq, PartialEq, Clone)]
 pub struct Clause {
     id: Option<u64>,
@@ -92,16 +91,15 @@ impl Clause {
         }
     }
 
-    /// Get the amount of symbols in this clause.
-    /// TODO: move somewhere else.
-    pub fn symbol_count(&self) -> usize {
-        self.literals.iter().fold(0, |acc, l| acc + l.symbol_count())
-    }
-
-    /// Set the id of the clause.
+    /// Set the ID of the clause.
     /// The IDs should be unique so care must be taken.
     pub fn set_id(&mut self, new_id: u64) {
         self.id = Some(new_id);
+    }
+    
+    /// Get the ID of the clause.
+    pub fn get_id(&self) -> u64 {
+        self.id.expect("ID should always exist")
     }
 }
 
@@ -123,20 +121,5 @@ impl Debug for Clause {
             }
         }
         write!(formatter, " }}")
-    }
-}
-
-/// The priority queue depends on "Ord".
-/// We order clauses in heuristic order, not in anything concrete.
-impl Ord for Clause {
-    fn cmp(&self, other: &Clause) -> Ordering {
-        other.symbol_count().cmp(&self.symbol_count())
-    }
-}
-
-/// "PartialOrd" needs to be implemented as well.
-impl PartialOrd for Clause {
-    fn partial_cmp(&self, other: &Clause) -> Option<Ordering> {
-        Some(other.symbol_count().cmp(&self.symbol_count()))
     }
 }

--- a/src/prover/data_structures/literal.rs
+++ b/src/prover/data_structures/literal.rs
@@ -84,12 +84,6 @@ impl Literal {
         (self.lhs == l.lhs && self.rhs == l.rhs) || (self.lhs == l.rhs && self.rhs == l.lhs)
     }
 
-    /// Get the amount of symbols in this literal
-    /// TODO: move this somewhere else.
-    pub fn symbol_count(&self) -> usize {
-        1 + self.lhs.symbol_count() + self.rhs.symbol_count()
-    }
-
     /// Used for iterating through the lhs and rhs of the literal.
     pub fn iter(&self) -> Iter {
         Iter {

--- a/src/prover/data_structures/term.rs
+++ b/src/prover/data_structures/term.rs
@@ -148,12 +148,6 @@ impl Term {
         }
     }
 
-    /// Get the amount of symbols in this term.
-    // TODO: move somewhere else.
-    pub fn symbol_count(&self) -> usize {
-        self.args.iter().fold(1, |acc, t| acc + t.symbol_count())
-    }
-
     /// Used for iterating the subterms of a term.
     pub fn iter(&self) -> Iter<Term> {
         self.args.iter()

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -35,6 +35,9 @@ mod data_structures;
 /// Contains functions for automatically determining good prover settings for a given problem.
 mod problem_analysis;
 
+/// Contains functions for selecting given clauses to analyze in the proof search.
+mod clause_selection;
+
 // TODO: figure out a new name for this.
 // flatten is just not descriptive and it also means something else on top of that.
 mod flatten_cnf;

--- a/src/prover/proof_state.rs
+++ b/src/prover/proof_state.rs
@@ -40,7 +40,7 @@ impl ProofState {
             used_clauses: Vec::new(),
             unused_clauses: HashMap::new(),
             term_ordering: term_order,
-            clause_order: vec![BinaryHeap::new(), BinaryHeap::new()],
+            clause_order: vec![BinaryHeap::new()],
             heuristic_order: vec![Heuristic::Size(2, 1)],
             heuristic_use_count: vec![5],
             current_heuristic_count: 0,

--- a/src/prover/proof_state.rs
+++ b/src/prover/proof_state.rs
@@ -14,26 +14,43 @@
 // along with Serkr. If not, see <http://www.gnu.org/licenses/>.
 //
 
-use std::collections::BinaryHeap;
+use std::collections::{HashMap, BinaryHeap};
 use prover::data_structures::clause::Clause;
 use prover::ordering::term_ordering::TermOrdering;
+use prover::clause_selection::clause_weight::ClauseWeight;
+use prover::clause_selection::heuristic::Heuristic;
+use prover::clause_selection::pick_best::{pick_best_clause, choose_heuristic};
 
 /// Contains the current proof state.
 /// That is, the used, the unused clauses and the term ordering used.
 pub struct ProofState {
     used_clauses: Vec<Clause>,
-    unused_clauses: BinaryHeap<Clause>,
+    unused_clauses: HashMap<u64, Clause>,
     term_ordering: TermOrdering,
+    clause_order: Vec<BinaryHeap<ClauseWeight>>,
+    heuristic_order: Vec<Heuristic>,
+    heuristic_use_count: Vec<usize>,
+    current_heuristic_count: usize,
 }
 
 impl ProofState {
     /// Creates a new proof state.
     pub fn new(preprocessed_clauses: Vec<Clause>, term_order: TermOrdering) -> ProofState {
-        ProofState {
+        let mut state = ProofState {
             used_clauses: Vec::new(),
-            unused_clauses: preprocessed_clauses.into_iter().collect(),
+            unused_clauses: HashMap::new(),
             term_ordering: term_order,
+            clause_order: vec![BinaryHeap::new(), BinaryHeap::new()],
+            heuristic_order: vec![Heuristic::Size(2, 1)],
+            heuristic_use_count: vec![5],
+            current_heuristic_count: 0,
+        };
+        
+        for cl in preprocessed_clauses.into_iter() {
+            state.add_to_unused(cl);
         }
+        
+        state
     }
 
     /// Get the amount of used clauses.
@@ -48,7 +65,8 @@ impl ProofState {
 
     /// Picks the best clause from unused and removes it from there.
     pub fn pick_best_clause(&mut self) -> Option<Clause> {
-        self.unused_clauses.pop()
+        let i = choose_heuristic(&self.heuristic_use_count, &mut self.current_heuristic_count);
+        pick_best_clause(&mut self.unused_clauses, &mut self.clause_order[i])
     }
 
     /// Adds the given clause to used clauses.
@@ -58,7 +76,11 @@ impl ProofState {
 
     /// Adds the given clause to unused clauses.
     pub fn add_to_unused(&mut self, cl: Clause) {
-        self.unused_clauses.push(cl);
+        for i in 0..self.heuristic_order.len() {
+            let cw = self.heuristic_order[i].new_clauseweight(&cl);
+            self.clause_order[i].push(cw);
+        }
+        self.unused_clauses.insert(cl.get_id(), cl);
     }
 
     /// Get a reference term ordering used.
@@ -69,12 +91,6 @@ impl ProofState {
     /// Get a reference to the used clauses.
     pub fn get_used(&self) -> &Vec<Clause> {
         &self.used_clauses
-    }
-
-    /// Get a reference to the unused clauses.
-    #[allow(dead_code)]
-    pub fn get_unused(&self) -> &BinaryHeap<Clause> {
-        &self.unused_clauses
     }
 
     /// Get a mutable reference to the used clauses.


### PR DESCRIPTION
Added the possibility of creating complex clause selection strategies from simpler ones. It was my intention to make the prover select 4 out of 5 clauses by their size, and 1 by its age since this is very likely an improvement over just selecting clauses by their size. However, since clauses selected by age are in general bigger than clauses selected by their size, the prover slows down dramatically in some problems, for example GEO297+1.p. Indexing techniques are needed to fix this, and until this is done we just select clauses by their size like previously.